### PR TITLE
User auth support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ app.env
 .env.development.local
 .env.test.local
 .env.production.local
+server/.env
 
 npm-debug.log*
 yarn-debug.log*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     ports:
       # allow override of published port
       - "127.0.0.1:${EXTERNAL_PORT:-9000}:8000"
+    volumes:
+      - shl-server-data:/app/db
   client:
     build: ./client
     ports:
@@ -16,3 +18,6 @@ services:
       - "127.0.0.1:${EXTERNAL_PORT:-9002}:3000"
     env_file:
       - ui/app.env
+
+volumes:
+  shl-server-data: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ version: "3.4"
 services:
   server:
     build: ./server
+    env_file:
+      - server/.env
     ports:
       # allow override of published port
       - "127.0.0.1:${EXTERNAL_PORT:-9000}:8000"

--- a/server/config.ts
+++ b/server/config.ts
@@ -2,7 +2,8 @@ const defaultEnv = {
   // PUBLIC_URL: 'http://localhost:8000',
   PUBLIC_URL: 'https://smart-health-links-server.cirg.washington.edu',
   FILE_SIZE_MAX: 1024 * 1024 * 100, // 100 MB
-  EMBEDDED_LENGTH_MAX: 10_000
+  EMBEDDED_LENGTH_MAX: 10_000, // 10 KB
+  JWKS_URL: "",
 };
 
 async function envOrDefault(variable: string, defaultValue: string | number) {

--- a/server/config.ts
+++ b/server/config.ts
@@ -1,8 +1,18 @@
-const defaultEnv = {
-  // PUBLIC_URL: 'http://localhost:8000',
-  PUBLIC_URL: 'https://smart-health-links-server.cirg.washington.edu',
+interface Config {
+  PUBLIC_URL: string;
+  EMBEDDED_LENGTH_MAX: number;
+  FILE_SIZE_MAX: number;
+  APP_VERSION_STRING?: string;
+  PORT?: number;
+  JWKS_URL?: string;
+};
+
+const defaultEnv: Config = {
+  PUBLIC_URL: 'http://localhost:8000',
   FILE_SIZE_MAX: 1024 * 1024 * 100, // 100 MB
   EMBEDDED_LENGTH_MAX: 10_000, // 10 KB
+  APP_VERSION_STRING: "",
+  PORT: 8000,
   JWKS_URL: "",
 };
 

--- a/server/db-migration.sql
+++ b/server/db-migration.sql
@@ -1,0 +1,103 @@
+/** Database migrations as of 2025-02-03, for user management updates */
+
+/** Update shlink_access log table name */
+ALTER TABLE shlink_access RENAME TO shlink_access_log;
+
+/** Update shlink access admin table name */
+ALTER TABLE shlink RENAME TO shlink_access;
+
+/** Add user table */
+CREATE TABLE IF NOT EXISTS user(
+  id VARCHAR(43) PRIMARY KEY UNIQUE
+);
+
+/** Add user_shlink table */
+CREATE TABLE IF NOT EXISTS user_shlink(
+  user VARCHAR(43) REFERENCES user(id),
+  shlink VARCHAR(43) REFERENCES shlink_access(id)
+);
+
+/** Add shlink_public table */
+CREATE TABLE IF NOT EXISTS shlink_public(
+  shlink VARCHAR(43) REFERENCES shlink_access(id),
+  manifest_url TEXT NOT NULL,
+  encryption_key VARCHAR(43) NOT NULL,
+  flag VARCHAR(3),
+  label VARCHAR(80),
+  version INTEGER DEFAULT 1
+);
+
+/** Update shlink_file */
+PRAGMA foreign_keys=off;
+BEGIN TRANSACTION;
+ALTER TABLE shlink_file RENAME TO _shlink_file_old;
+CREATE TABLE IF NOT EXISTS shlink_file(
+  shlink VARCHAR(43) REFERENCES shlink_access(id),
+  label VARCHAR(80) DEFAULT NULL,
+  added_time DATETIME NOT NULL DEFAULT(DATETIME('now')),
+  content_type TEXT NOT NULL DEFAULT "application/json",
+  content_hash TEXT REFERENCES cas_item(hash)
+);
+INSERT INTO shlink_file (shlink, content_type, content_hash)
+  SELECT shlink, content_type, content_hash
+  FROM _shlink_file_old;
+COMMIT;
+PRAGMA foreign_keys=on;
+
+DROP TABLE _shlink_file_old;
+
+/** Update shlink_endpoint */
+PRAGMA foreign_keys=off;
+BEGIN TRANSACTION;
+ALTER TABLE shlink_endpoint RENAME TO _shlink_endpoint_old;
+CREATE TABLE IF NOT EXISTS shlink_endpoint(
+  id VARCHAR(43) PRIMARY KEY UNIQUE,
+  shlink VARCHAR(43) REFERENCES shlink_access(id),
+  added_time DATETIME NOT NULL DEFAULT(DATETIME('now')),
+  endpoint_url TEXT NOT NULL,
+  config_key VARCHAR(43) NOT NULL,
+  config_client_id TEXT NOT NULL,
+  config_client_secret TEXT,
+  config_token_endpoint TEXT NOT NULL,
+  config_refresh_token TEXT NOT NULL,
+  refresh_time TEXT NOT NULL DEFAULT(DATETIME('now', '+5 minutes')),
+  access_token_response TEXT NOT NULL
+);
+INSERT INTO shlink_endpoint (
+  id,
+  shlink,
+  endpoint_url,
+  config_key,
+  config_client_id,
+  config_client_secret,
+  config_token_endpoint,
+  config_refresh_token,
+  refresh_time,
+  access_token_response
+)
+SELECT
+  id,
+  shlink,
+  endpoint_url,
+  config_key,
+  config_client_id,
+  config_client_secret,
+  config_token_endpoint,
+  config_refresh_token,
+  refresh_time,
+  access_token_response
+FROM _shlink_endpoint_old;
+COMMIT;
+PRAGMA foreign_keys=on;
+
+DROP TABLE _shlink_endpoint_old;
+
+/** Update disable_shlink_on_passcode_failure trigger */
+DROP TRIGGER disable_shlink_on_passcode_failure;
+
+CREATE TRIGGER IF NOT EXISTS disable_shlink_on_passcode_failure
+AFTER UPDATE ON shlink_access
+FOR EACH ROW
+  BEGIN
+      UPDATE shlink_access SET active=false WHERE id=new.id AND passcode_failures_remaining <= 0;
+  END;

--- a/server/db.ts
+++ b/server/db.ts
@@ -2,6 +2,7 @@ import { base64url, queryString, sqlite } from './deps.ts';
 import { clientConnectionListener } from './routers/api.ts';
 import * as types from './types.ts';
 import { randomStringWithEntropy } from './util.ts';
+import env from './config.ts';
 
 const { DB } = sqlite;
 
@@ -37,12 +38,11 @@ async function updateAccessToken(endpoint: types.HealthLinkEndpoint) {
 }
 
 export const DbLinks = {
-  handleUser(userid: string) {
-    if (this.userExists(userid)) {
-      return 
-    }
+  createUser(userid: string) {
+    return db.query(`INSERT or ignore INTO user (id) values (?)`, [userid]);
   },
   create(config: types.HealthLinkConfig) {
+    this.createUser(config.userId);
     const link = {
       config,
       id: randomStringWithEntropy(32),
@@ -50,7 +50,7 @@ export const DbLinks = {
       active: true,
     };
     db.query(
-      `INSERT INTO shlink (id, management_token, active, config_exp, config_passcode)
+      `INSERT INTO shlink_access (id, management_token, active, config_exp, config_passcode)
       values (:id, :managementToken, :active, :exp, :passcode)`,
       {
         id: link.id,
@@ -61,30 +61,65 @@ export const DbLinks = {
       },
     );
 
+    db.query(
+      `INSERT INTO user_shlink (user, shlink)
+      values (:user, :shlink)`,
+      {
+        user: config.userId,
+        shlink: link.id,
+      },
+    );
+
     const link_public = {
       id: link.id,
-      manifestUrl: `${Deno.env.get('PUBliC_URL')}/api/shl/${link.id}`,
+      manifestUrl: `${env.PUBLIC_URL}/api/shl/${link.id}`,
       key: randomStringWithEntropy(32),
       flag: link.config.passcode ? 'P' : '',
-      label: config.label
+      label: config.label,
+      version: 1
     }
 
     db.query(
-      `INSERT INTO shlink_public (shlink, manifest_url, encryption_key, flag, label)
-      values (:shlink, :manifestUrl, :encryptionKey, :flag, :label)`,
+      `INSERT INTO shlink_public (shlink, manifest_url, encryption_key, flag, label, version)
+      values (:shlink, :manifestUrl, :encryptionKey, :flag, :label, :version)`,
       {
         shlink: link_public.id,
         manifestUrl: link_public.manifestUrl,
         encryptionKey: link_public.key,
         flag: link_public.flag,
-        label: link_public.label
+        label: link_public.label,
+        version: link_public.version
       },
     );
 
-    return link_public;
+    return {
+      id: link_public.id as string,
+      url: link_public.manifestUrl as string,
+      key: link_public.key as string,
+      flag: link_public.flag as string,
+      label: link_public.label as string,
+      v: link_public.version as number,
+      files: [],
+      config: {
+        exp: link.config.exp as number,
+        passcode: link.config.passcode as string
+      },
+      managementToken: link.managementToken as string
+    };
+  },
+  getConfig(shlId: types.HealthLink) {
+    let shl = db.prepareQuery(`SELECT * from shlink_access where shlink=?`).oneEntry([shlId]);
+    if (!shl) {
+      return false;
+    }
+    return {
+      exp: shl.config_exp,
+      passcode: shl.config_passcode,
+      label: shl.label
+    };
   },
   updateConfig(shl: types.HealthLink) {
-    let pub = db.query(`SELECT * from shlink_public where shlink=?`).oneEntry([shl.id]);
+    let pub = db.prepareQuery(`SELECT * from shlink_public where shlink=?`).oneEntry([shl.id]);
     if (!pub) {
       return false;
     }
@@ -104,7 +139,7 @@ export const DbLinks = {
         }
       );
       db.query(
-        `UPDATE shlink set config_passcode=:passcode, config_exp=:exp where id=:id`,
+        `UPDATE shlink_access set config_passcode=:passcode, config_exp=:exp where id=:id`,
         {
           id: shl.id,
           exp: shl.config.exp,
@@ -115,48 +150,48 @@ export const DbLinks = {
     return true;
   },
   deactivate(shl: types.HealthLink) {
-    db.query(`UPDATE shlink set active=false where id=?`, [shl.id]);
-    return true;
+    try {
+      db.query(`UPDATE shlink_access set active=false where id=?`, [shl.id]);
+    } catch (e) {
+      return false;
+    }
+    return shl.id;
   },
-  reactivate(linkId: string, managementToken: string): boolean {
-    db.query(`UPDATE shlink set active=true, passcode_failures_remaining=5 where id=? and management_token=?`, [linkId, managementToken]);
+  reactivate(shl: types.HealthLink): boolean {
+    db.query(`UPDATE shlink_access set active=true, passcode_failures_remaining=5 where id=?`, [shl.id]);
     return true;
   },
   linkExists(linkId: string): boolean {
-    return Boolean(db.query(`SELECT * from shlink where id=? and active=1`, [linkId]));
+    return Boolean(db.query(`SELECT * from shlink_access where id=? and active=1`, [linkId]));
   },
   userExists(userId: string): boolean {
     return Boolean(db.query(`SELECT * from user where id=?`, [userId]));
   },
-  getUserShls(userId: string): types.HealthLink | undefined {
-    try {
-      const linkRow = db
-        .prepareQuery(`SELECT * from shlink where user_id=? and active=1 order by created desc limit 1`)
-        .allEntries([userId]);
-      // TODO: fix
-      const linkPub = db
-        .prepareQuery(`SELECT * from shlink_public where shlink=?`)
-        .allEntries([linkRow.id]);
-      return {
-        id: linkRow.id as string,
-        passcodeFailuresRemaining: linkRow.passcode_failures_remaining as number,
-        active: Boolean(linkRow.active) as boolean,
-        sessionId: linkRow.session_id as string,
-        created: linkRow.created as string,
-        managementToken: linkRow.management_token as string,
-        config: {
-          exp: linkRow.config_exp as number,
-          passcode: linkRow.config_passcode as string,
-        },
-      };
-    } catch (e) {
-      console.warn(e);
-      return undefined;
-    }
+  managementTokenExists(managementToken: string): boolean {
+    return Boolean(db.query(`SELECT * from shlink_access where management_token=?`, [managementToken]));
+  },
+  getManagementTokenUserInternal(managementToken: string): string {
+    const result = db.prepareQuery(
+      `SELECT * from shlink_access JOIN user_shlink on shlink_access.id=user_shlink.shlink where management_token=?`
+    ).oneEntry([managementToken]);
+    return result.user as string;
+  },
+  getShlInternal(linkId: string): types.HealthLink {
+    const linkRow = db.prepareQuery(`SELECT * from shlink_access where id=?`).oneEntry([linkId]);
+    return {
+      id: linkRow.id as string,
+      passcodeFailuresRemaining: linkRow.passcode_failures_remaining as number,
+      active: Boolean(linkRow.active) as boolean,
+      managementToken: linkRow.management_token as string,
+      config: {
+        exp: linkRow.config_exp as number,
+        passcode: linkRow.config_passcode as string,
+      },
+    };
   },
   getManagedShl(linkId: string, managementToken: string): types.HealthLink {
     const linkRow = db
-      .prepareQuery(`SELECT * from shlink where id=? and management_token=?`)
+      .prepareQuery(`SELECT * from shlink_access where id=? and management_token=?`)
       .oneEntry([linkId, managementToken]);
 
     return {
@@ -170,57 +205,123 @@ export const DbLinks = {
       },
     };
   },
-  getShlInternal(linkId: string): types.HealthLink {
-    const linkRow = db.prepareQuery(`SELECT * from shlink where id=?`).oneEntry([linkId]);
-    return {
-      id: linkRow.id as string,
-      passcodeFailuresRemaining: linkRow.passcode_failures_remaining as number,
-      active: Boolean(linkRow.active) as boolean,
-      managementToken: linkRow.management_token as string,
-      config: {
-        exp: linkRow.config_exp as number,
-        passcode: linkRow.config_passcode as string,
-      },
-    };
+  getUserShl(linkId: string, userId: string): types.HealthLink {
+    try {
+      const userRow = db
+        .prepareQuery(`SELECT * from user_shlink where shlink=? and user=?`)
+        .oneEntry([linkId, userId]);
+
+      if (!userRow) {
+        return;
+      }
+      
+      const linkRow = db
+        .prepareQuery(`SELECT * from shlink_access where id=?`)
+        .oneEntry([linkId]);
+  
+      return {
+        id: linkRow.id as string,
+        passcodeFailuresRemaining: linkRow.passcode_failures_remaining as number,
+        active: Boolean(linkRow.active) as boolean,
+        managementToken: linkRow.management_token as string,
+        config: {
+          exp: linkRow.config_exp as number,
+          passcode: linkRow.config_passcode as string,
+        },
+      };
+    } catch (e) {
+      console.error(e);
+      return;
+    }
   },
-  async addFile(linkId: string, file: types.HealthLinkFile): Promise<string> {
+  getUserShls(userId: string): Array<types.HealthLink> | undefined {
+    try {
+      const userPubShls = db
+        .prepareQuery(`
+          SELECT
+            shlink_public.*,
+            shlink_access.config_passcode,
+            shlink_access.config_exp,
+            shlink_access.management_token
+          FROM user_shlink
+          JOIN shlink_public on shlink_public.shlink=user_shlink.shlink
+          JOIN shlink_access on shlink_access.id=user_shlink.shlink
+          WHERE
+            user_shlink.user=?
+            and shlink_access.active=1
+          `)
+        .allEntries([userId])
+        .map( row => {
+          return {
+            id: row.shlink as string,
+            url: row.manifest_url as string,
+            exp: row.config_exp as number,
+            key: row.encryption_key as string,
+            flag: row.flag as string,
+            label: row.label as string,
+            v: row.version as number,
+            files: this.getFiles(row.shlink as string),
+            config: {
+              exp: row.config_exp as number,
+              passcode: row.config_passcode as string
+            },
+            managementToken: row.management_token as string
+          }
+        });
+      return userPubShls;
+    } catch (e) {
+      console.error(e);
+    }
+  },
+  async addFile(linkId: string, file: types.HealthLinkFile) {
     const hash = await crypto.subtle.digest('SHA-256', file.content);
     const hashEncoded = base64url.encode(hash);
-    db.query(`insert or ignore into cas_item(hash, content) values(:hashEncoded, :content)`, {
-      hashEncoded,
-      content: file.content,
-    });
-
-    db.query(
-      `insert into shlink_file(shlink, content_type, content_hash) values (:linkId, :contentType, :hashEncoded)`,
-      {
-        linkId,
-        contentType: file.contentType,
-        hashEncoded,
-      },
-    );
+    try {
+      db.transaction(() => {
+        db.query(`insert or ignore into cas_item(hash, content) values(:hashEncoded, :content)`, {
+          hashEncoded,
+          content: file.content,
+        });
+    
+        db.query(
+          `insert into shlink_file(shlink, content_type, content_hash) values (:linkId, :contentType, :hashEncoded)`,
+          {
+            linkId,
+            contentType: file.contentType,
+            hashEncoded,
+          },
+        );
+      });
+    } catch (e) {
+      console.error(e);
+      return false;
+    }
 
     return hashEncoded;
   },
   async deleteFile(linkId: string, content: Uint8Array) {
     const hash = await crypto.subtle.digest('SHA-256', content);
     const hashEncoded = base64url.encode(hash);
-
-    db.query(
-      `delete from shlink_file where shlink = :linkId and content_hash = :hashEncoded`,
-      {
-        linkId,
-        hashEncoded,
-      }
-    );
-
+    try {
+      db.query(
+        `delete from shlink_file where shlink = :linkId and content_hash = :hashEncoded`,
+        {
+          linkId,
+          hashEncoded,
+        }
+      );
+    } catch (e) {
+      console.error(e);
+      return false;
+    }
+    // Hard delete
     // db.query(`delete from cas_item where hash = :hashEncoded and content = :content`,
     // {
     //   hashEncoded,
     //   content: file.content,
     // });
 
-    return true;
+    return hashEncoded as string;
   },
   async deleteAllFiles(linkId: string) {
 
@@ -352,8 +453,23 @@ export const DbLinks = {
       contentType: fileRow[0].content_type,
     };
   },
+  getFiles(shlId: string): types.HealthLinkFile[] {
+    const files = db.queryEntries<{
+      label: string;
+      added_time: string;
+      content_type: string;
+    }>(
+      `select * from shlink_file where shlink=?`,
+      [shlId],
+    );
+    return files.map((f) => ({
+      label: f.label,
+      added: f.added_time,
+      contentType: f.content_type,
+    }));
+  },
   recordAccess(shlId: string, recipient: string) {
-    const q = db.prepareQuery(`insert into  shlink_access(shlink, recipient) values (?, ?)`);
+    const q = db.prepareQuery(`insert into  shlink_access_log(shlink, recipient) values (?, ?)`);
     q.execute([shlId, recipient]);
 
     clientConnectionListener({
@@ -363,7 +479,7 @@ export const DbLinks = {
   },
   recordPasscodeFailure(shlId: string) {
     const q = db.prepareQuery(
-      `update shlink set passcode_failures_remaining = passcode_failures_remaining - 1 where id=?`
+      `update shlink_access set passcode_failures_remaining = passcode_failures_remaining - 1 where id=?`
     );
     q.execute([shlId]);
   },

--- a/server/db.ts
+++ b/server/db.ts
@@ -74,7 +74,7 @@ export const DbLinks = {
       id: link.id,
       manifestUrl: `${env.PUBLIC_URL}/api/shl/${link.id}`,
       key: randomStringWithEntropy(32),
-      flag: link.config.passcode.length > 0 ? 'P' : '',
+      flag: 'P',
       label: config.label,
       version: 1
     }
@@ -124,17 +124,15 @@ export const DbLinks = {
       return false;
     }
     let newFlag = pub.flag;
-    if (shl.config.passcode && !pub.flag.includes('P')) {
+    if (!pub.flag.includes('P')) {
       newFlag = pub.flag + 'P';
-    } else if (shl.config.passcode.length > 0) {
-      newFlag = pub.flag.replace('P', '');
     }
     db.transaction(() => {
       db.query(
         `UPDATE shlink_public set flag=:flag, label=:label where shlink=:id`,
         {
           id: shl.id,
-          flag: shl.config.passcode.length > 0 ? 'P' : '',
+          flag: newFlag,
           label: shl.label
         }
       );

--- a/server/default.env
+++ b/server/default.env
@@ -1,0 +1,17 @@
+# Server base URL
+PUBLIC_URL=
+
+# Max size for returned manifest files
+#EMBEDDED_LENGTH_MAX=
+
+# Max size for uploaded files
+#FILE_SIZE_MAX=
+
+# VCS version string if not using CI image
+#APP_VERSION_STRING=
+
+# local deploy server port
+#PORT=
+
+# IDP jwks url for jwt auth
+#JWKS_URL=

--- a/server/routers/api.ts
+++ b/server/routers/api.ts
@@ -58,7 +58,7 @@ router.post('/shl/:shlId', async (context) => {
     context.response.headers.set('content-type', 'application/json');
     return;
   }
-  if (shl.config.exp && new Date(shl.config.exp * 1000).getTime() < new Date().getTime()) {
+  if (shl.config.exp !== undefined && new Date(shl.config.exp * 1000).getTime() < new Date().getTime()) {
     context.response.status = 404;
     context.response.body = { message: "SHL is expired" };
     context.response.headers.set('content-type', 'application/json');

--- a/server/routers/api.ts
+++ b/server/routers/api.ts
@@ -26,268 +26,179 @@ interface ManifestAccessTicket {
 }
 const manifestAccessTickets: Map<string, ManifestAccessTicket> = new Map();
 
-export const shlApiRouter = new oak.Router()
-  .post('/shl', async (context) => {
-    const config: types.HealthLinkConfig = await context.request.body({ type: 'json' }).value;
-    const newLink = db.DbLinks.create(config);
-    console.log("Created link " + newLink.id);
-    context.response.body = {
-      ...newLink,
-      files: undefined,
-      config: undefined,
-    };
-  })
-  .post('/shl/:shlId', async (context) => {
-    const config: types.HealthLinkManifestRequest = await context.request.body({ type: 'json' }).value;
-    const embeddedLengthMax = Math.min(env.EMBEDDED_LENGTH_MAX, config.embeddedLengthMax !== undefined ? config.embeddedLengthMax : Infinity);
+export const router = new oak.Router();
 
-    let shl: types.HealthLink;
-    try {
-      shl = db.DbLinks.getShlInternal(context.params.shlId);
-    } catch {
-      context.response.status = 404;
-      context.response.body = { message: "SHL does not exist or has been deactivated."};
-      context.response.headers.set('content-type', 'application/json');
-      return;
-    }
+/**
+ * Open endpoints for SHL and content access
+ */
+/** Request SHL manifest */
+router.post('/shl/:shlId', async (context) => {
+  const config: types.HealthLinkManifestRequest = await context.request.body({ type: 'json' }).value;
+  const embeddedLengthMax = Math.min(env.EMBEDDED_LENGTH_MAX, config.embeddedLengthMax !== undefined ? config.embeddedLengthMax : Infinity);
 
-    if (!shl?.active) {
-      context.response.status = 404;
-      context.response.body = { message: "SHL does not exist or has been deactivated." };
-      context.response.headers.set('content-type', 'application/json');
-      return;
-    }
-    if (shl.config.exp && new Date(shl.config.exp * 1000).getTime() < new Date().getTime()) {
-      context.response.status = 403;
-      context.response.body = { message: "SHL is expired" };
-      context.response.headers.set('content-type', 'application/json');
-      return;
-    }
-    if (shl.config.passcode && !("passcode" in config)) {
-      context.response.status = 401;
-      context.response.body = {
-        message: "Password required",
-        remainingAttempts: shl.passcodeFailuresRemaining
-      }
-      context.response.headers.set('content-type', 'application/json');
-      return;
-    }
-    if (shl.config.passcode && shl.config.passcode !== config.passcode) {
-      db.DbLinks.recordPasscodeFailure(shl.id);
-      context.response.status = 401;
-      context.response.body = {
-        message: "Incorrect password",
-        remainingAttempts: shl.passcodeFailuresRemaining - 1
-      };
-      context.response.headers.set('content-type', 'application/json');
-      return;
-    }
-
-    const ticket = randomStringWithEntropy(32);
-    manifestAccessTickets.set(ticket, {
-      shlId: shl.id,
-    });
-    setTimeout(() => {
-      manifestAccessTickets.delete(ticket);
-    }, 60000);
-    db.DbLinks.recordAccess(shl.id, config.recipient);
-
-    context.response.headers.set('expires', new Date().toUTCString());
-    context.response.body = {
-      files: db.DbLinks.getManifestFiles(shl.id, embeddedLengthMax)
-        .map((f, _i) => ({
-          contentType: f.contentType,
-          embedded: f.content?.length ? new TextDecoder().decode(f.content) : undefined,
-          location: `${env.PUBLIC_URL}/api/shl/${shl.id}/file/${f.hash}?ticket=${ticket}`,
-        }))
-        .concat(
-          db.DbLinks.getManifestEndpoints(shl.id).map((e) => ({
-            contentType: 'application/smart-api-access',
-            embedded: undefined,
-            location: `${env.PUBLIC_URL}/api/shl/${shl.id}/endpoint/${e.id}?ticket=${ticket}`,
-          })),
-        ),
-    };
-    context.response.headers.set('content-type', 'application/json');
-  })
-  .put('/shl/:shlId', async (context) => {
-    const managementToken = await context.request.headers.get('authorization')?.split(/bearer /i)[1]!;
-    const config: types.HealthLinkConfig = await context.request.body({ type: 'json' }).value;
-    if (!db.DbLinks.linkExists(context.params.shlId)) {
-      context.response.status = 404;
-      context.response.body = { message: "SHL does not exist or has been deactivated." };
-      context.response.headers.set('content-type', 'application/json');
-      return;
-    }
-    const shl = db.DbLinks.getManagedShl(context.params.shlId, managementToken)!;
-    if (!shl) {
-      context.response.status = 401;
-      context.response.body = { message: `Unauthorized` };
-      context.response.headers.set('content-type', 'application/json');
-      return;
-    }
-    shl.config.exp = config.exp ?? shl.config.exp;
-    shl.config.passcode = config.passcode ?? shl.config.passcode;
-    const updated = db.DbLinks.updateConfig(shl);
-    const updatedShl = db.DbLinks.getManagedShl(context.params.shlId, managementToken)!;
-    context.response.body = updatedShl;
-    context.response.headers.set('content-type', 'application/json');
-  })
-  .get('/shl/:shlId/active', (context) => {
-    const shl = db.DbLinks.getShlInternal(context.params.shlId);
-    if (!shl) {
-      context.response.status = 404;
-      context.response.body = { message: `Deleted` };
-      context.response.headers.set('content-type', 'application/json');
-      return;
-    }
-    const isActive = (shl && shl.active);
-    console.log(context.params.shlId + " active: " + isActive);
-    context.response.body = isActive;
+  let shl: types.HealthLink;
+  try {
+    shl = db.DbLinks.getShlInternal(context.params.shlId);
+  } catch {
+    context.response.status = 404;
+    context.response.body = { message: "SHL does not exist or has been deactivated."};
     context.response.headers.set('content-type', 'application/json');
     return;
-  })
-  .put('/shl/:shlId/reactivate', async (context) => {
-    const managementToken = await context.request.headers.get('authorization')?.split(/bearer /i)[1]!;
-    const success = db.DbLinks.reactivate(context.params.shlId, managementToken)!;
-    console.log("Reactivated " + context.params.shlId + ": " + success);
+  }
+
+  if (!shl?.active) {
+    context.response.status = 404;
+    context.response.body = { message: "SHL does not exist or has been deactivated." };
     context.response.headers.set('content-type', 'application/json');
-    return (context.response.body = success);
-  })
-  .get('/shl/:shlId/file/:fileIndex', (context) => {
-    const ticket = manifestAccessTickets.get(context.request.url.searchParams.get('ticket')!);
-    if (!ticket) {
-      console.log('Cannot request SHL without a valid ticket');
-      context.response.status = 401;
-      context.response.body = { message: "Unauthorized" }
-      context.response.headers.set('content-type', 'application/json');
-      return;
-    }
-
-    if (ticket.shlId !== context.params.shlId) {
-      console.log('Ticket is not valid for ' + context.params.shlId);
-      context.response.status = 401;
-      context.response.body = { message: "Unauthorized" }
-      context.response.headers.set('content-type', 'application/json');
-      return;
-    }
-
-    const file = db.DbLinks.getFile(context.params.shlId, context.params.fileIndex);
-    context.response.headers.set('content-type', 'application/jose');
-    context.response.body = file.content;
-  })
-  .get('/shl/:shlId/endpoint/:endpointId', async (context) => {
-    const ticket = manifestAccessTickets.get(context.request.url.searchParams.get('ticket')!);
-    if (!ticket) {
-      console.log('Cannot request SHL without a valid ticket');
-      context.response.status = 401;
-      context.response.body = { message: "Unauthorized" }
-      context.response.headers.set('content-type', 'application/json');
-      return;
-    }
-
-    if (ticket.shlId !== context.params.shlId) {
-      console.log('Ticket is not valid for ' + context.params.shlId);
-      context.response.status = 401;
-      context.response.body = { message: "Unauthorized" };
-      context.response.headers.set('content-type', 'application/json');
-      return;
-    }
-
-    const endpoint = await db.DbLinks.getEndpoint(context.params.shlId, context.params.endpointId);
-    context.response.headers.set('content-type', 'application/jose');
-    const payload = JSON.stringify({
-      aud: endpoint.endpointUrl,
-      ...endpoint.accessTokenResponse,
-    });
-    const encrypted = await new jose.CompactEncrypt(new TextEncoder().encode(payload))
-      .setProtectedHeader({
-        alg: 'dir',
-        enc: 'A256GCM',
-      })
-      .encrypt(jose.base64url.decode(endpoint.config.key));
-    context.response.body = encrypted;
-  })
-  .post('/shl/:shlId/file', async (context) => {
-    const managementToken = await context.request.headers.get('authorization')?.split(/bearer /i)[1]!;
-    const newFileBody = await context.request.body({
-      type: 'bytes',
-      limit: fileSizeMax
-    });
-
-    if (!db.DbLinks.linkExists(context.params.shlId)) {
-      context.response.status = 404;
-      context.response.body = { message: "SHL does not exist or has been deactivated." };
-      context.response.headers.set('content-type', 'application/json');
-      return;
-    }
-    const shl = db.DbLinks.getManagedShl(context.params.shlId, managementToken)!;
-    if (!shl) {
-      context.response.status = 401;
-      context.response.body = { message: `Unauthorized` };
-      context.response.headers.set('content-type', 'application/json');
-      return;
-    }
-
-    let contentLength = context.request.headers.get('content-length');
-    if (contentLength === null) {
-      context.response.status = 400;
-      context.response.body = { message: `Missing content length` };
-      context.response.headers.set('content-type', 'application/json');
-      return;
-    }
-    if (Number(contentLength) > fileSizeMax) {
-      context.response.status = 413;
-      context.response.body = { message: `Size limit exceeded` };
-      context.response.headers.set('content-type', 'application/json');
-      return;
-    }
-
-    const newFile = {
-      contentType: context.request.headers.get('content-type')!,
-      content: await newFileBody.value,
-    };
-
-    const added = db.DbLinks.addFile(shl.id, newFile);
+    return;
+  }
+  if (shl.config.exp && new Date(shl.config.exp * 1000).getTime() < new Date().getTime()) {
+    context.response.status = 403;
+    context.response.body = { message: "SHL is expired" };
+    context.response.headers.set('content-type', 'application/json');
+    return;
+  }
+  if (shl.config.passcode && !("passcode" in config)) {
+    context.response.status = 401;
     context.response.body = {
-      ...shl,
-      added,
-    };
-  })
-  .delete('/shl/:shlId/file', async (context) => {
-    const managementToken = await context.request.headers.get('authorization')?.split(/bearer /i)[1]!;
-    const currentFileBody = await context.request.body({type: 'bytes'});
-    if (!db.DbLinks.linkExists(context.params.shlId)) {
-      context.response.status = 404;
-      context.response.body = { message: "SHL does not exist or has been deactivated." };
-      context.response.headers.set('content-type', 'application/json');
-      return;
-    }
-    const shl = db.DbLinks.getManagedShl(context.params.shlId, managementToken)!;
-    if (!shl) {
-      context.response.status = 401;
-      context.response.body = { message: `Unauthorized` };
-      context.response.headers.set('content-type', 'application/json');
-      return;
-    }
-    
-    const deleted = db.DbLinks.deleteFile(shl.id, await currentFileBody.value);
-    context.response.body = {
-      ...shl,
-      deleted,
+      message: "Password required",
+      remainingAttempts: shl.passcodeFailuresRemaining
     }
     context.response.headers.set('content-type', 'application/json');
-  })
-  .post('/shl/:shlId/endpoint', async (context) => {
-    const managementToken = await context.request.headers.get('authorization')?.split(/bearer /i)[1]!;
-    const config: types.HealthLinkEndpoint = await context.request.body({ type: 'json' }).value;
+    return;
+  }
+  if (shl.config.passcode && shl.config.passcode !== config.passcode) {
+    db.DbLinks.recordPasscodeFailure(shl.id);
+    context.response.status = 401;
+    context.response.body = {
+      message: "Incorrect password",
+      remainingAttempts: shl.passcodeFailuresRemaining - 1
+    };
+    context.response.headers.set('content-type', 'application/json');
+    return;
+  }
 
-    if (!db.DbLinks.linkExists(context.params.shlId)) {
-      context.response.status = 404;
-      context.response.body = { message: "SHL does not exist or has been deactivated." };
-      context.response.headers.set('content-type', 'application/json');
-      return;
-    }
+  const ticket = randomStringWithEntropy(32);
+  manifestAccessTickets.set(ticket, {
+    shlId: shl.id,
+  });
+  setTimeout(() => {
+    manifestAccessTickets.delete(ticket);
+  }, 60000);
+  db.DbLinks.recordAccess(shl.id, config.recipient);
+
+  context.response.headers.set('expires', new Date().toUTCString());
+  context.response.body = {
+    files: db.DbLinks.getManifestFiles(shl.id, embeddedLengthMax)
+      .map((f, _i) => ({
+        contentType: f.contentType,
+        embedded: f.content?.length ? new TextDecoder().decode(f.content) : undefined,
+        location: `${env.PUBLIC_URL}/api/shl/${shl.id}/file/${f.hash}?ticket=${ticket}`,
+      }))
+      .concat(
+        db.DbLinks.getManifestEndpoints(shl.id).map((e) => ({
+          contentType: 'application/smart-api-access',
+          embedded: undefined,
+          location: `${env.PUBLIC_URL}/api/shl/${shl.id}/endpoint/${e.id}?ticket=${ticket}`,
+        })),
+      ),
+  };
+  context.response.headers.set('content-type', 'application/json');
+});
+/** Request SHL file from manifest */
+router.get('/shl/:shlId/file/:fileIndex', (context) => {
+  const ticket = manifestAccessTickets.get(context.request.url.searchParams.get('ticket')!);
+  if (!ticket) {
+    console.log('Cannot request SHL without a valid ticket');
+    context.response.status = 401;
+    context.response.body = { message: "Unauthorized" }
+    context.response.headers.set('content-type', 'application/json');
+    return;
+  }
+
+  if (ticket.shlId !== context.params.shlId) {
+    console.log('Ticket is not valid for ' + context.params.shlId);
+    context.response.status = 401;
+    context.response.body = { message: "Unauthorized" }
+    context.response.headers.set('content-type', 'application/json');
+    return;
+  }
+
+  const file = db.DbLinks.getFile(context.params.shlId, context.params.fileIndex);
+  context.response.headers.set('content-type', 'application/jose');
+  context.response.body = file.content;
+});
+/** [Deprecated] Demo iis endpoint for HIMSS 2024 */
+router.post('/iis', async(context) => {
+  const content = await context.request.body({ type: 'json' }).value;
+  const response = await fetch('http://35.160.125.146:8039/fhir/Patient/', {
+    method: 'POST',
+    headers: content.headers,
+    body: JSON.stringify(content)
+  });
+  if (response.ok) {
+    const body = await response.json();
+    context.response.body = body;
+  } else {
+    throw new Error('Unable to fetch IIS immunization data');
+  };
+});
+
+/**
+ * Middleware for JWT validation in front of below routes if necessary
+ */
+if (Deno.env.get('JWKS_URL')) {
+  router.use(authMiddleware);
+}
+
+/**
+ * Endpoints behind JWT validation middleware when enabled
+*/
+/** Create SHL */
+router.post('/shl', async (context) => {
+  const config: types.HealthLinkConfig = await context.request.body({ type: 'json' }).value;
+  const newLink = db.DbLinks.create(config);
+  console.log("Created link " + newLink.id);
+  context.response.body = {
+    ...newLink,
+    files: undefined,
+    config: undefined,
+  };
+});
+/** Update SHL */
+router.put('/shl/:shlId', async (context) => {
+  const managementToken = await context.request.headers.get('authorization')?.split(/bearer /i)[1]!;
+  const config: types.HealthLinkConfig = await context.request.body({ type: 'json' }).value;
+  if (!db.DbLinks.linkExists(context.params.shlId)) {
+    context.response.status = 404;
+    context.response.body = { message: "SHL does not exist or has been deactivated." };
+    context.response.headers.set('content-type', 'application/json');
+    return;
+  }
+  const shl = db.DbLinks.getManagedShl(context.params.shlId, managementToken)!;
+  if (!shl) {
+    context.response.status = 401;
+    context.response.body = { message: `Unauthorized` };
+    context.response.headers.set('content-type', 'application/json');
+    return;
+  }
+  shl.config.exp = config.exp ?? shl.config.exp;
+  shl.config.passcode = config.passcode ?? shl.config.passcode;
+  const updated = db.DbLinks.updateConfig(shl);
+  const updatedShl = db.DbLinks.getManagedShl(context.params.shlId, managementToken)!;
+  context.response.body = updatedShl;
+  context.response.headers.set('content-type', 'application/json');
+});
+/** Deactivate SHL */
+router.delete('/shl/:shlId', async (context) => {
+  const managementToken = await context.request.headers.get('authorization')?.split(/bearer /i)[1]!;
+  if (!db.DbLinks.linkExists(context.params.shlId)) {
+    context.response.status = 404;
+    context.response.body = { message: "SHL does not exist or has been deactivated." };
+    context.response.headers.set('content-type', 'application/json');
+    return;
+  }
+  try {
     const shl = db.DbLinks.getManagedShl(context.params.shlId, managementToken)!;
     if (!shl) {
       context.response.status = 401;
@@ -295,101 +206,268 @@ export const shlApiRouter = new oak.Router()
       context.response.headers.set('content-type', 'application/json');
       return;
     }
-
-    const added = await db.DbLinks.addEndpoint(shl.id, config);
-    console.log("Added", added)
-    context.response.body = {
-      ...shl,
-      added,
-    };
-  })
-  .delete('/shl/:shlId', async (context) => {
-    const managementToken = await context.request.headers.get('authorization')?.split(/bearer /i)[1]!;
-    if (!db.DbLinks.linkExists(context.params.shlId)) {
-      context.response.status = 404;
-      context.response.body = { message: "SHL does not exist or has been deactivated." };
-      context.response.headers.set('content-type', 'application/json');
-      return;
-    }
-    try {
-      const shl = db.DbLinks.getManagedShl(context.params.shlId, managementToken)!;
-      if (!shl) {
-        context.response.status = 401;
-        context.response.body = { message: `Unauthorized` };
-        context.response.headers.set('content-type', 'application/json');
-        return;
-      }
-      const deactivated = db.DbLinks.deactivate(shl);
-      context.response.body = deactivated;
-    } catch {
-      context.response.status = 404;
-      context.response.body = { message: "SHL does not exist" };
-      context.response.headers.set('content-type', 'application/json');
-      return;
-    }
-  })
-  .post('/subscribe', async (context) => {
-    const shlSet: { shlId: string; managementToken: string }[] = await context.request.body({ type: 'json' }).value;
-    const managedLinks = shlSet.map((req) => db.DbLinks.getManagedShl(req.shlId, req.managementToken));
-
-    const ticket = randomStringWithEntropy(32, 'subscription-ticket-');
-    subscriptionTickets.set(
-      ticket,
-      managedLinks.map((l) => l.id),
-    );
-    setTimeout(() => {
-      subscriptionTickets.delete(ticket);
-    }, 10000);
-    context.response.body = { subscribe: `${env.PUBLIC_URL}/api/subscribe/${ticket}` };
-  })
-  .get('/subscribe/:ticket', (context) => {
-    const validForSet = subscriptionTickets.get(context.params.ticket);
-    if (!validForSet) {
-      throw 'Invalid ticket for SSE subscription';
-    }
-
-    const target = context.sendEvents();
-    for (const shl of validForSet) {
-      if (!accessLogSubscriptions.has(shl)) {
-        accessLogSubscriptions.set(shl, []);
-      }
-      accessLogSubscriptions.get(shl)!.push(target);
-      target.dispatchEvent(new oak.ServerSentEvent('status', db.DbLinks.getShlInternal(shl)));
-    }
-
-    const keepaliveInterval = setInterval(() => {
-      target.dispatchEvent(new oak.ServerSentEvent('keepalive', JSON.stringify({ shlCount: validForSet.length })));
-    }, 15000);
-
-    target.addEventListener('close', () => {
-      clearInterval(keepaliveInterval);
-      for (const shl of validForSet) {
-        const idx = accessLogSubscriptions.get(shl)!.indexOf(target);
-        accessLogSubscriptions.get(shl)!.splice(idx, 1);
-      }
-    });
-  })
-  .post('/iis', async(context) => {
-    const content = await context.request.body({ type: 'json' }).value;
-    const response = await fetch('http://35.160.125.146:8039/fhir/Patient/', {
-      method: 'POST',
-      headers: content.headers,
-      body: JSON.stringify(content)
-    });
-    if (response.ok) {
-      const body = await response.json();
-      context.response.body = body;
-    } else {
-      throw new Error('Unable to fetch IIS immunization data');
-    };
+    const deactivated = db.DbLinks.deactivate(shl);
+    context.response.body = deactivated;
+  } catch {
+    context.response.status = 404;
+    context.response.body = { message: "SHL does not exist" };
+    context.response.headers.set('content-type', 'application/json');
+    return;
+  }
+});
+/** Check if SHL is active */
+router.get('/shl/:shlId/active', (context) => {
+  const shl = db.DbLinks.getShlInternal(context.params.shlId);
+  if (!shl) {
+    context.response.status = 404;
+    context.response.body = { message: `Deleted` };
+    context.response.headers.set('content-type', 'application/json');
+    return;
+  }
+  const isActive = (shl && shl.active);
+  console.log(context.params.shlId + " active: " + isActive);
+  context.response.body = isActive;
+  context.response.headers.set('content-type', 'application/json');
+  return;
+});
+/** Reactivate SHL */
+router.put('/shl/:shlId/reactivate', async (context) => {
+  const managementToken = await context.request.headers.get('authorization')?.split(/bearer /i)[1]!;
+  const success = db.DbLinks.reactivate(context.params.shlId, managementToken)!;
+  console.log("Reactivated " + context.params.shlId + ": " + success);
+  context.response.headers.set('content-type', 'application/json');
+  return (context.response.body = success);
+});
+/** Add file to SHL */
+router.post('/shl/:shlId/file', async (context) => {
+  const managementToken = await context.request.headers.get('authorization')?.split(/bearer /i)[1]!;
+  const newFileBody = await context.request.body({
+    type: 'bytes',
+    limit: fileSizeMax
   });
 
-/*
-  .post('/register', (context) => {
-  })
-  /*
-    files: DbLinks.fileNames(client.shlink).map(
-            (f, _i) => ({contentType: f.contentType, location: `${env.PUBLIC_URL}/api/shl/${client.shlink}/file/${f}`}),
-    ),
+  if (!db.DbLinks.linkExists(context.params.shlId)) {
+    context.response.status = 404;
+    context.response.body = { message: "SHL does not exist or has been deactivated." };
+    context.response.headers.set('content-type', 'application/json');
+    return;
+  }
+  const shl = db.DbLinks.getManagedShl(context.params.shlId, managementToken)!;
+  if (!shl) {
+    context.response.status = 401;
+    context.response.body = { message: `Unauthorized` };
+    context.response.headers.set('content-type', 'application/json');
+    return;
+  }
 
-  */
+  let contentLength = context.request.headers.get('content-length');
+  if (contentLength === null) {
+    context.response.status = 400;
+    context.response.body = { message: `Missing content length` };
+    context.response.headers.set('content-type', 'application/json');
+    return;
+  }
+  if (Number(contentLength) > fileSizeMax) {
+    context.response.status = 413;
+    context.response.body = { message: `Size limit exceeded` };
+    context.response.headers.set('content-type', 'application/json');
+    return;
+  }
+
+  const newFile = {
+    contentType: context.request.headers.get('content-type')!,
+    content: await newFileBody.value,
+  };
+
+  const added = db.DbLinks.addFile(shl.id, newFile);
+  context.response.body = {
+    ...shl,
+    added,
+  };
+});
+/** Delete file from SHL */
+router.delete('/shl/:shlId/file', async (context) => {
+  const managementToken = await context.request.headers.get('authorization')?.split(/bearer /i)[1]!;
+  const currentFileBody = await context.request.body({type: 'bytes'});
+  if (!db.DbLinks.linkExists(context.params.shlId)) {
+    context.response.status = 404;
+    context.response.body = { message: "SHL does not exist or has been deactivated." };
+    context.response.headers.set('content-type', 'application/json');
+    return;
+  }
+  const shl = db.DbLinks.getManagedShl(context.params.shlId, managementToken)!;
+  if (!shl) {
+    context.response.status = 401;
+    context.response.body = { message: `Unauthorized` };
+    context.response.headers.set('content-type', 'application/json');
+    return;
+  }
+  
+  const deleted = db.DbLinks.deleteFile(shl.id, await currentFileBody.value);
+  context.response.body = {
+    ...shl,
+    deleted,
+  }
+  context.response.headers.set('content-type', 'application/json');
+});
+/** Add endpoint to SHL */
+router.post('/shl/:shlId/endpoint', async (context) => {
+  const managementToken = await context.request.headers.get('authorization')?.split(/bearer /i)[1]!;
+  const config: types.HealthLinkEndpoint = await context.request.body({ type: 'json' }).value;
+
+  if (!db.DbLinks.linkExists(context.params.shlId)) {
+    context.response.status = 404;
+    context.response.body = { message: "SHL does not exist or has been deactivated." };
+    context.response.headers.set('content-type', 'application/json');
+    return;
+  }
+  const shl = db.DbLinks.getManagedShl(context.params.shlId, managementToken)!;
+  if (!shl) {
+    context.response.status = 401;
+    context.response.body = { message: `Unauthorized` };
+    context.response.headers.set('content-type', 'application/json');
+    return;
+  }
+
+  const added = await db.DbLinks.addEndpoint(shl.id, config);
+  console.log("Added", added)
+  context.response.body = {
+    ...shl,
+    added,
+  };
+});
+/** Request SHL endpoint from manifest */
+router.get('/shl/:shlId/endpoint/:endpointId', async (context) => {
+  const ticket = manifestAccessTickets.get(context.request.url.searchParams.get('ticket')!);
+  if (!ticket) {
+    console.log('Cannot request SHL without a valid ticket');
+    context.response.status = 401;
+    context.response.body = { message: "Unauthorized" }
+    context.response.headers.set('content-type', 'application/json');
+    return;
+  }
+
+  if (ticket.shlId !== context.params.shlId) {
+    console.log('Ticket is not valid for ' + context.params.shlId);
+    context.response.status = 401;
+    context.response.body = { message: "Unauthorized" };
+    context.response.headers.set('content-type', 'application/json');
+    return;
+  }
+
+  const endpoint = await db.DbLinks.getEndpoint(context.params.shlId, context.params.endpointId);
+  context.response.headers.set('content-type', 'application/jose');
+  const payload = JSON.stringify({
+    aud: endpoint.endpointUrl,
+    ...endpoint.accessTokenResponse,
+  });
+  const encrypted = await new jose.CompactEncrypt(new TextEncoder().encode(payload))
+    .setProtectedHeader({
+      alg: 'dir',
+      enc: 'A256GCM',
+    })
+    .encrypt(jose.base64url.decode(endpoint.config.key));
+  context.response.body = encrypted;
+});
+/** Subscribe to SHLs related to a management token */
+router.post('/subscribe', async (context) => {
+  const shlSet: { shlId: string; managementToken: string }[] = await context.request.body({ type: 'json' }).value;
+  const managedLinks = shlSet.map((req) => db.DbLinks.getManagedShl(req.shlId, req.managementToken));
+
+  const ticket = randomStringWithEntropy(32, 'subscription-ticket-');
+  subscriptionTickets.set(
+    ticket,
+    managedLinks.map((l) => l.id),
+  );
+  setTimeout(() => {
+    subscriptionTickets.delete(ticket);
+  }, 10000);
+  context.response.body = { subscribe: `${env.PUBLIC_URL}/api/subscribe/${ticket}` };
+});
+/** Get subscribed SHLs for a ticket */
+router.get('/subscribe/:ticket', (context) => {
+  const validForSet = subscriptionTickets.get(context.params.ticket);
+  if (!validForSet) {
+    throw 'Invalid ticket for SSE subscription';
+  }
+
+  const target = context.sendEvents();
+  for (const shl of validForSet) {
+    if (!accessLogSubscriptions.has(shl)) {
+      accessLogSubscriptions.set(shl, []);
+    }
+    accessLogSubscriptions.get(shl)!.push(target);
+    target.dispatchEvent(new oak.ServerSentEvent('status', db.DbLinks.getShlInternal(shl)));
+  }
+
+  const keepaliveInterval = setInterval(() => {
+    target.dispatchEvent(new oak.ServerSentEvent('keepalive', JSON.stringify({ shlCount: validForSet.length })));
+  }, 15000);
+
+  target.addEventListener('close', () => {
+    clearInterval(keepaliveInterval);
+    for (const shl of validForSet) {
+      const idx = accessLogSubscriptions.get(shl)!.indexOf(target);
+      accessLogSubscriptions.get(shl)!.splice(idx, 1);
+    }
+  });
+});
+
+/*
+router.post('/register', (context) => {
+})
+/*
+  files: DbLinks.fileNames(client.shlink).map(
+          (f, _i) => ({contentType: f.contentType, location: `${env.PUBLIC_URL}/api/shl/${client.shlink}/file/${f}`}),
+  ),
+
+*/
+
+/** JWT validation middleware */
+async function authMiddleware(ctx, next) {
+  const token = ctx.request.headers.get('Authorization');
+  if (!token) {
+    ctx.response.status = 400;
+    ctx.response.body = { message: 'token missing' };
+    return;
+  }
+
+  const tokenValue = token.split(' ')[1];
+  if (!tokenValue) {
+    ctx.response.status = 400;
+    ctx.response.body = { message: 'token missing' };
+    return;
+  }
+
+  const jwksClient = await fetch(Deno.env.get('JWKS_URL'));
+  const jwks = await jwksClient.json();
+
+  const signingKey = jwks.keys.find((key) => key.kid === tokenValue.kid);
+  if (!signingKey) {
+    ctx.response.status = 401;
+    ctx.response.body = { message: 'invalid token' };
+    return;
+  }
+
+  try {
+    const decodedToken = await jose.jwtVerify(tokenValue, signingKey, {
+      algorithms: ['RS256'],
+      audience: ['account'],
+    });
+    ctx.state.user = decodedToken.payload;
+    
+    await next();
+  
+  } catch (error) {
+    if (error instanceof jose.jwt.JWTExpired) {
+      ctx.response.status = 401;
+      ctx.response.body = { message: 'token expired' };
+    } else {
+      ctx.response.status = 401;
+      ctx.response.body = { message: 'invalid token' };
+    }
+    return;
+  }
+}
+
+export const shlApiRouter = router;

--- a/server/routers/api.ts
+++ b/server/routers/api.ts
@@ -225,7 +225,7 @@ router.post('/shl', async (context) => {
   console.log("Config posted:" + JSON.stringify(config));
   const newLink = db.DbLinks.create(config);
   console.log("Created link " + newLink.id);
-  const encodedPayload: string = jose.base64url.encode(JSON.stringify(prepareShlForReturn(newLink)));
+  const encodedPayload: string = jose.base64url.encode(JSON.stringify(prepareMinimalShlForReturn(newLink)));
   const shlinkBare = `shlink:/${encodedPayload}`;
   context.response.headers.set('content-type', 'application/json');
   return (context.response.body = shlinkBare);
@@ -531,6 +531,26 @@ async function authMiddleware(ctx, next) {
     }
     return;
   }
+}
+
+function prepareMinimalShlForReturn(shl: types.HealthLinkFull) {
+  let flat = {
+    ...shl,
+    ...shl.config,
+  };
+  const keys = [
+    "id",
+    "url",
+    "key",
+    "exp",
+    "flag",
+    "label",
+    "v",
+  ];
+  const subset = Object.fromEntries(
+    Object.entries(flat).filter(([key]) => keys.includes(key))
+  );
+  return subset;
 }
 
 function prepareShlForReturn(shl: types.HealthLinkFull) {

--- a/server/routers/api.ts
+++ b/server/routers/api.ts
@@ -67,7 +67,7 @@ router.post('/shl/:shlId', async (context) => {
   if (shl.config.passcode && !("passcode" in config)) {
     context.response.status = 401;
     context.response.body = {
-      message: "Password required",
+      message: "Passcode required",
       remainingAttempts: shl.passcodeFailuresRemaining
     }
     context.response.headers.set('content-type', 'application/json');

--- a/server/routers/api.ts
+++ b/server/routers/api.ts
@@ -59,7 +59,7 @@ router.post('/shl/:shlId', async (context) => {
     return;
   }
   if (shl.config.exp && new Date(shl.config.exp * 1000).getTime() < new Date().getTime()) {
-    context.response.status = 403;
+    context.response.status = 404;
     context.response.body = { message: "SHL is expired" };
     context.response.headers.set('content-type', 'application/json');
     return;

--- a/server/routers/api.ts
+++ b/server/routers/api.ts
@@ -232,7 +232,7 @@ router.post('/shl', async (context) => {
   console.log("Created link " + newLink.id);
   const encodedPayload: string = jose.base64url.encode(JSON.stringify(prepareMinimalShlForReturn(newLink)));
   const shlinkBare = `shlink:/${encodedPayload}`;
-  context.response.headers.set('content-type', 'application/json');
+  context.response.headers.set('content-type', 'text/plain');
   context.response.body = shlinkBare;
   return;
 });

--- a/server/routers/api.ts
+++ b/server/routers/api.ts
@@ -213,6 +213,15 @@ router.use(authMiddleware);
  * TODO: Change to GET after committing to jwt auth
  * Current body required: { userId: string }
 */
+/** Simple auth check endpoint to open auth middleware check to external services */
+router.post('/authcheck', async (context) => {
+  const userId = context.state.auth.sub;
+  if (!userId) {
+    context.response.status = 401;
+    context.response.body = { message: `Unauthorized` };
+    context.response.headers.set('Content-Type', 'application/json');
+  }
+});
 /** Get SHLs for user */
 router.post('/user', async (context: oak.Context) => {
   const shls = db.DbLinks.getUserShls(context.state.auth.sub)!;

--- a/server/routers/api.ts
+++ b/server/routers/api.ts
@@ -232,7 +232,7 @@ router.post('/shl', async (context) => {
   console.log("Created link " + newLink.id);
   const encodedPayload: string = jose.base64url.encode(JSON.stringify(prepareMinimalShlForReturn(newLink)));
   const shlinkBare = `shlink:/${encodedPayload}`;
-  context.response.headers.set('content-type', 'text/plain');
+  context.response.headers.set('content-type', 'text/plain; charset=utf-8');
   context.response.body = shlinkBare;
   return;
 });

--- a/server/routers/api.ts
+++ b/server/routers/api.ts
@@ -225,7 +225,10 @@ router.post('/shl', async (context) => {
   console.log("Config posted:" + JSON.stringify(config));
   const newLink = db.DbLinks.create(config);
   console.log("Created link " + newLink.id);
-  return (context.response.body = prepareShlForReturn(newLink));
+  const encodedPayload: string = jose.base64url.encode(JSON.stringify(prepareShlForReturn(newLink)));
+  const shlinkBare = `shlink:/${encodedPayload}`;
+  context.response.headers.set('content-type', 'application/json');
+  return (context.response.body = shlinkBare);
 });
 /** Update SHL */
 router.put('/shl/:shlId', async (context) => {

--- a/server/routers/api.ts
+++ b/server/routers/api.ts
@@ -109,7 +109,7 @@ router.post('/shl/:shlId', async (context) => {
           location: `${env.PUBLIC_URL}/api/shl/${shl.id}/endpoint/${e.id}?ticket=${ticket}`,
         })),
       ),
-  });
+  };
   return;
 });
 /** Request SHL file from manifest */

--- a/server/schema.sql
+++ b/server/schema.sql
@@ -25,7 +25,7 @@ CREATE TABLE IF NOT EXISTS shlink_access(
 CREATE TABLE IF NOT EXISTS shlink_public(
   shlink VARCHAR(43) REFERENCES shlink_access(id),
   manifest_url TEXT NOT NULL,
-  encryption_key VARCHAR(43),
+  encryption_key VARCHAR(43) NOT NULL,
   flag VARCHAR(3),
   label VARCHAR(80),
   version INTEGER DEFAULT 1

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "target": "esnext",
+  },
+}

--- a/server/types.ts
+++ b/server/types.ts
@@ -22,6 +22,7 @@ export interface HealthLinkEndpoint {
 }
 
 export interface HealthLinkConfig {
+  userId?: string;
   passcode?: string;
   exp?: number;
   label?: string;

--- a/server/types.ts
+++ b/server/types.ts
@@ -36,10 +36,21 @@ export interface HealthLink {
   passcodeFailuresRemaining: number;
 }
 
+export interface HealthLinkFull extends SHLDecoded, Omit<HealthLink, 'passcodeFailuresRemaining' | 'active'> {
+  files: FileSummary[];
+}
+
 export interface HealthLinkManifestRequest {
   recipient: string;
   passcode?: string;
   embeddedLengthMax?: number;
+}
+
+export interface FileSummary {
+  label?: string;
+  added: string;
+  contentType: string;
+  contentHash: string;
 }
 
 export interface SHLinkManifestFile {
@@ -62,4 +73,5 @@ export interface SHLDecoded {
   key: string & { length: 43 };
   exp?: number;
   label?: string;
+  v?: number;
 }

--- a/server/types.ts
+++ b/server/types.ts
@@ -24,6 +24,7 @@ export interface HealthLinkEndpoint {
 export interface HealthLinkConfig {
   passcode?: string;
   exp?: number;
+  label?: string;
 }
 
 export interface HealthLink {


### PR DESCRIPTION
Support for user SHL management workflows, including Keycloak authentication with JWT validation
- Protects SHL create and update operations protected behind auth check middleware
  - Checks JWT against JWKS url (keycloak secret) and validates user access permissions
  - Allows all requests containing "userId" param (IHE projectathon stopgap)
  - Allows all requests containing valid management token as Bearer auth (IHE projectathon stopgap, interim while auth is finalized)
- Adds user-shl linking and management
- Adds shl content fields (previously assumed to be managed on client side)
- Updates shl content fields to match spec (adds url, always assign passcode flag, "encryptionKey" -> "key")
- Adds files list to shl content to support front-end content displays
- Adds file label field
- Updates file date field name
- Updates method return types and consistency
- Adds database volume
- Adds version string to CI build
- Bug fixes